### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "c"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # ECSE-427-Operating-Systems
+[![Run on Repl.it](https://repl.it/badge/github/Tempeus/ECSE-427-Operating-Systems)](https://repl.it/github/Tempeus/ECSE-427-Operating-Systems)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).